### PR TITLE
README: fix typo & document URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ class WebmEncoder {
 
 ## Demos
 
-To run the web demos, start the websever using
+To run the web demos, start the webserver using
 
 ```
 $ npm run serve
 ```
+
+You'll find the demos at http://localhost:8080/demo/ .
 
 To run the node demos, run them directly (requires Node 11+):
 


### PR DESCRIPTION
For a second, I was confused when the demo webservice served the entire repository instead of just the demos.
Simply adding a link fixes this problem and makes it easier to see the demos.